### PR TITLE
chore: Release PyPI CD

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.9.22", "3.10.17", "3.11.12", "3.12.8"]
+        python-version: ["3.12.8"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
- changed python-version matrix to solely 3.12.8
- previous development failured due to multiple artifacts with the same name