### PR TITLE
Fix GitHub Action to avoid boolean prompt during PyPI release

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -254,7 +254,7 @@ jobs:
       - name: Publish to PyPI
         run: |
           poetry config pypi-token.pypi "${{ secrets.PYPI_TOKEN }}"
-          poetry publish --build || {
+          poetry publish || {
             echo "Poetry publish failed, falling back to twine"
             poetry run twine upload \
               --verbose \


### PR DESCRIPTION
This pull request makes a small change to the PyPI publishing workflow. It removes the `--build` flag from the `poetry publish` command in `.github/workflows/release_pypi.yaml`, which means the build step is no longer performed as part of the publish command.…action, which i cannot interact with the terminal

## Description  
**What**: Briefly summarize the changes (e.g., "Added user authentication module").  
**Why**: Explain the motivation (e.g., "To comply with new security policies").  
**How**: Link to implementation details (e.g., "Used OAuth2.0 via Auth0").  

---

## Changes Made
**Added**:
- New feature: [Description].  
- Dependency: [Package@version].  

**Updated**:
- Refactored [Component] for [Reason].  

**Fixed**:
- Issue #[Number]: [Brief description].  

---

## Testing
### Manual Testing
- **Test Case 1**:  
    - Steps: `1. Navigate to /login → 2. Submit credentials`  
    - Expected: Redirect to dashboard.  
    - Evidence: ![Screenshot](link).  
- **Test Case 2**:  
    - Steps: `Simulate network failure during API call`.  
    - Expected: Graceful error handling.  

### Automated Testing
- **Unit Tests**:  
    - File: `test_auth.py`  
    - Coverage: 95% (via `pytest --cov`).  
- **Integration Tests**:  
    - File: `tests.yaml`  
    - Status: `OK/NOK`.  

**Not Applicable**:  
- Explain (e.g., "Documentation-only change").  

---

## Documentation
- **Code**:
    - Updated docstrings in [files].  
- **Guides**:
    - Added [section] to README.  
- **Changelog**:
    - Entry under [Version].  

---

## Additional Notes  
**Dependencies**:  
- Blocks/Depends on #[PR Number].  

**Follow-up**:  
- Tech debt: [Brief note].  

**Reviewer Focus**:  
- Pay attention to [specific files/logic].  
