### PR TITLE
fix(build): drop poetry update from bump_version recipe

### DIFF
--- a/bin/bump_version.sh
+++ b/bin/bump_version.sh
@@ -100,10 +100,11 @@ main() {
     if ! update_init_version "$new_version"; then
         exit 1
     fi
-    
-    print_status "info" "Updating dependencies..."
-    poetry update
-    
+
+    # Intentionally no `poetry update` here: a version bump must not re-resolve
+    # dependencies. The CI venv cache keys on pyproject.toml, so bumping forces a
+    # fresh install — re-resolving the lock at bump time silently ships dependency
+    # changes (and broke the test suite on a release bump). Update deps separately.
     print_status "success" "Version update complete!"
 }
 


### PR DESCRIPTION
## Description
**What**: Remove the `poetry update` step from `bin/bump_version.sh` (the `make bump_version` recipe).
**Why**: A version bump must not re-resolve dependencies. `poetry update` regenerated the whole lock during a release bump; because the CI venv cache keys on `pyproject.toml` (`.github/workflows/tests.yaml:54`), the version change forced a **fresh install**, so the re-resolved lock shipped silently and broke ~hundreds of unit tests on Python 3.13 (observed on PR #101).
**How**: Drop the `poetry update` call (and its info line) from `main()`; add a comment explaining why it must not come back. Updating dependencies stays a separate, deliberate action.

---

## Changes Made
**Updated**:
- `bin/bump_version.sh` `main()`: removed `poetry update`; the recipe now only bumps the version in `pyproject.toml` and the `__version__` fallback in `stpstone/__init__.py`.

**Fixed**:
- Release version bumps no longer drag in unintended dependency re-resolution that can break CI.

---

## Testing
### Automated Testing
- **Static checks**: `bash -n bin/bump_version.sh` (parse) and `shellcheck --severity=warning --exclude=SC1091 bin/bump_version.sh` both clean.

**Not Applicable**:
- No unit tests — shell tooling change. Behaviour verified by static analysis and the surrounding context (PR #101, where restoring the un-updated lock turned CI green: 6874 unit tests passed on a fresh Python 3.13 install).

---

## Documentation
- **Code**: Added an inline comment in `bin/bump_version.sh` documenting why `poetry update` must not be re-added.

---

## Additional Notes
**Reviewer Focus**:
- `main()` in `bin/bump_version.sh` — confirm the recipe should only touch the version, not the lock.
- No `tasks.sh` exists in this repo, so no parallel recipe to keep in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
